### PR TITLE
Switch to crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 description = "A plugin to prevent certain types from being dropped, thus making them linear"
 repository = "https://github.com/Manishearth/humpty_dumpty"
 readme = "README.md"
+license = "MPL-2.0"
 keywords = ["linear", "drop", "plugin"]
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,15 @@
 name = "humpty_dumpty"
 version = "0.0.1"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
+description = "A plugin to prevent certain types from being dropped, thus making them linear"
+repository = "https://github.com/Manishearth/humpty_dumpty"
+readme = "README.md"
+keywords = ["linear", "drop", "plugin"]
+
 
 [lib]
 name = "humpty_dumpty"
-crate_type = ["dylib"]
+plugin = true
 
-[dev-dependencies.compiletest]
-git = "https://github.com/laumann/compiletest-rs.git"
+[dev-dependencies]
+compiletest_rs = "*"

--- a/tests/compile_test.rs
+++ b/tests/compile_test.rs
@@ -1,4 +1,4 @@
-extern crate compiletest;
+extern crate compiletest_rs as compiletest;
 
 use std::env;
 use std::process::Command;


### PR DESCRIPTION
I haven't yet added a license; I'm thinking of using MPL-2.0

Once this merges (and once we add a license to the toml file), we can
publish this to crates.io whenever we want to.

r? @Munksgaard
